### PR TITLE
CopyOptions content_only field

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,7 @@ fn prepare_tensorflow_source() -> PathBuf {
         skip_exist: false,
         buffer_size: 65536,
         copy_inside: false,
+        content_only: false,
         depth: 0,
     };
 


### PR DESCRIPTION
Hello, 

I was trying to use edgetpu-rs when I stumbled over this error. Without this content_only field on the CopyOptions struct in build.rs the compiler gets unhappy and throws you an error. After this small tweak the library again works as intended. Please also accept the pull request on your edgetpu-rs updating the tflite-rs commit ref.

Best Regards,
littleTitan